### PR TITLE
Fix row names in multiple_comparisons table

### DIFF
--- a/R/mct.R
+++ b/R/mct.R
@@ -470,6 +470,8 @@ multiple_comparisons <- function(model.obj,
         attr(pp.tab, 'aliased') <- as.character(aliased_names)
     }
 
+    rownames(pp.tab) <- NULL
+  
     return(pp.tab)
 }
 


### PR DESCRIPTION
When printing the multiple_comparisons table, the row names are not from 1 to n. I'm just resetting the order before returning the object.