### PR TITLE
Add trans="cloglog" and trans="boxcox"

### DIFF
--- a/R/mct.R
+++ b/R/mct.R
@@ -408,6 +408,44 @@ multiple_comparisons <- function(model.obj,
             pp.tab$low <- 1/(pp.tab$predicted.value - pp.tab$ci)
             pp.tab$up <- 1/(pp.tab$predicted.value + pp.tab$ci)
         }
+      if (trans == "boxcox") { #include trans="boxcox" for transformations in the form dry_weight^lambda-1)/lambda, I am considering power=lambda for this transformation
+        pp.tab$PredictedValue <- (power*pp.tab$predicted.value+1)^(1/power) - 
+          ifelse(!is.na(offset), offset, 0)
+        
+        pp.tab$ApproxSE <- (power*pp.tab$std.error+1) * (1/(power * 
+                                                              pp.tab$PredictedValue^(power - 1))) #not sure about se
+        if (int.type == "ci") {
+          pp.tab$ci <- stats::qt(p = sig, ndf, lower.tail = FALSE) * 
+            pp.tab$std.error
+        }
+        if (int.type == "1se") {
+          pp.tab$ci <- pp.tab$std.error
+        }
+        if (int.type == "2se") {
+          pp.tab$ci <- 2 * pp.tab$std.error
+        }
+        pp.tab$low <- (power*(pp.tab$predicted.value - pp.tab$ci)+1)^(1/power) - 
+          ifelse(!is.na(offset), offset, 0) #not sure about low and up as is returning negative values
+        pp.tab$up <- (power*(pp.tab$predicted.value + pp.tab$ci)+1)^(1/power) - 
+          ifelse(!is.na(offset), offset, 0)
+      }
+      
+      if (trans == "cloglog") { #include trans="cloglog" link
+        pp.tab$PredictedValue <- 1-exp(-exp(pp.tab$predicted.value)) 
+        pp.tab$ApproxSE <- abs(pp.tab$std.error) * pp.tab$PredictedValue
+        if (int.type == "ci") {
+          pp.tab$ci <- stats::qt(p = sig, ndf, lower.tail = FALSE) * 
+            pp.tab$std.error
+        }
+        if (int.type == "1se") {
+          pp.tab$ci <- pp.tab$std.error
+        }
+        if (int.type == "2se") {
+          pp.tab$ci <- 2 * pp.tab$std.error
+        }
+        pp.tab$low <- 1-exp(-exp(pp.tab$predicted.value - pp.tab$ci)) 
+        pp.tab$up <- 1-exp(-exp(pp.tab$predicted.value + pp.tab$ci))
+      }
     }
 
     else {


### PR DESCRIPTION
Please review and consider including transformations for "cloglog" and "boxcox".

The boxcox transformation is other type than the one in the documentation.

For boxcox I am considering the following transformation to the response variable: 

```
cox<-MASS::boxcox(biom$dry_weight~biom$treatment)
lambda<-cox$x[which.max(cox$y)]
biom$trans_dry_weight<-(dry_weight^lambda-1)/lambda

```

The response also has a +1 (not shown), so I left the offset in the equation and use offset=1 when applying the function. I also use power=lambda when applying the function.

The predicted values are very close to my data means. However, "low" has negative values, thus transformation might not be correct. I am also unsure about the SE. 

I really appreciate if you could fix what I could not get right and implement these two transformations.

I have added code to perform the transformations on L411 to L448.



Kind regards



