### PR TITLE
Update install_asreml.R

### DIFF
--- a/R/install_asreml.R
+++ b/R/install_asreml.R
@@ -393,7 +393,7 @@ newer_version <- function() {
     }
 
     nv <- max(numeric_version(as.character(newest$asr_ver)))
-    newest <- newest[which(newest$asr_ver==nv), ]
+    newest <- newest[which.max(newest$`Date published`), , drop = FALSE] 
 
     # Get current version info
     if(rlang::is_installed("asreml")) {


### PR DESCRIPTION
Makes sure to only return the newest version as one row.

Error in (newest$`Date published` > asr_date + 7) && (numeric_version(as.character(newest$asr_ver)) >  :
  'length = 3' in coercion to 'logical(1)'